### PR TITLE
Move from hard-coded city structs to loading from JSON

### DIFF
--- a/data/cities.json
+++ b/data/cities.json
@@ -1,0 +1,244 @@
+{
+    "cities": [
+        {
+            "name":    "SanFrancisco",
+            "disease": "Blue",
+            "neighbors": ["LosAngeles", "Tokyo", "Manila", "Chicago"]
+        },
+        {
+            "name":    "Washington",
+            "disease": "Blue",
+            "neighbors": ["Miami", "Atlanta", "Montreal", "NewYork"]
+        },
+        {
+            "name":    "Atlanta",
+            "disease": "Blue",
+            "neighbors": ["Chicago", "Washington", "Miami"]
+        },
+        {
+            "name":    "Montreal",
+            "disease": "Blue",
+            "neighbors": ["Chicago", "NewYork", "Washington"]
+        },
+        {
+            "name":    "Chicago",
+            "disease": "Blue",
+            "neighbors": ["Montreal", "Atlanta", "MexicoCity", "LosAngeles", "SanFrancisco"]
+        },
+        {
+            "name":    "NewYork",
+            "disease": "Blue",
+            "neighbors": ["Montreal", "Washington", "London", "Madrid"]
+        },
+        {
+            "name":    "London",
+            "disease": "Blue",
+            "neighbors": ["NewYork", "Essen", "Paris", "Madrid"]
+        },
+        {
+            "name":    "Essen",
+            "disease": "Blue",
+            "neighbors": ["London", "StPetersburg", "Milan", "Paris"]
+        },
+        {
+            "name":    "StPetersburg",
+            "disease": "Blue",
+            "neighbors": ["Essen", "Moscow", "Istanbul"]
+        },
+        {
+            "name":    "Milan",
+            "disease": "Blue",
+            "neighbors": ["Paris", "Essen", "Istanbul"]
+        },
+        {
+            "name":    "Paris",
+            "disease": "Blue",
+            "neighbors": ["Madrid", "London", "Essen", "Milan", "Algiers"]
+        },
+        {
+            "name":    "Madrid",
+            "disease": "Blue",
+            "neighbors": ["NewYork", "London", "Paris", "Algiers", "SaoPaulo"]
+        },
+        {
+            "name":    "LosAngeles",
+            "disease": "Yellow",
+            "neighbors": ["SanFrancisco", "Chicago", "MexicoCity", "Lima", "Sydney"]
+        },
+        {
+            "name":    "Miami",
+            "disease": "Yellow",
+            "neighbors": ["Atlanta", "Washington", "Bogota", "MexicoCity"]
+        },
+        {
+            "name":    "MexicoCity",
+            "disease": "Yellow",
+            "neighbors": ["LosAngeles", "Chicago", "Miami", "Bogota", "Lima"]
+        },
+        {
+            "name":    "Bogota",
+            "disease": "Yellow",
+            "neighbors": ["Miami", "SaoPaulo", "BuenosAires", "Lima", "MexicoCity"]
+        },
+        {
+            "name":    "Lima",
+            "disease": "Yellow",
+            "neighbors": ["LosAngeles", "MexicoCity", "Bogota", "Santiago"]
+        },
+        {
+            "name":    "Santiago",
+            "disease": "Yellow",
+            "neighbors": ["Lima", "BuenosAires"]
+        },
+        {
+            "name":    "SaoPaulo",
+            "disease": "Yellow",
+            "neighbors": ["BuenosAires", "Bogota", "Madrid", "Lagos"]
+        },
+        {
+            "name":    "BuenosAires",
+            "disease": "Yellow",
+            "neighbors": ["Santiago", "Bogota", "SaoPaulo", "Johannesburg"]
+        },
+        {
+            "name":    "Lagos",
+            "disease": "Yellow",
+            "neighbors": ["SaoPaulo", "Kinshasa", "Khartoum"]
+        },
+        {
+            "name":    "Khartoum",
+            "disease": "Yellow",
+            "neighbors": ["Johannesburg", "Kinshasa", "Lagos", "Cairo"]
+        },
+        {
+            "name":    "Kinshasa",
+            "disease": "Yellow",
+            "neighbors": ["Lagos", "Khartoum", "Johannesburg"]
+        },
+        {
+            "name":    "Johannesburg",
+            "disease": "Yellow",
+            "neighbors": ["BuenosAires", "Kinshasa", "Khartoum"]
+        },
+        {
+            "name":    "Algiers",
+            "disease": "Black",
+            "neighbors": ["Madrid", "Paris", "Istanbul", "Cairo"]
+        },
+        {
+            "name":    "Istanbul",
+            "disease": "Black",
+            "neighbors": ["Milan", "StPetersburg", "Moscow", "Baghdad", "Cairo", "Algiers"]
+        },
+        {
+            "name":    "Cairo",
+            "disease": "Black",
+            "neighbors": ["Algiers", "Istanbul", "Baghdad", "Riydah", "Khartoum"]
+        },
+        {
+            "name":    "Riydah",
+            "disease": "Black",
+            "neighbors": ["Cairo", "Baghdad", "Karachi"]
+        },
+        {
+            "name":    "Baghdad",
+            "disease": "Black",
+            "neighbors": ["Istanbul", "Tehran", "Riydah", "Cairo"]
+        },
+        {
+            "name":    "Moscow",
+            "disease": "Black",
+            "neighbors": ["StPetersburg", "Tehran", "Istanbul"]
+        },
+        {
+            "name":    "Tehran",
+            "disease": "Black",
+            "neighbors": ["Moscow", "Delhi", "Karachi", "Baghdad"]
+        },
+        {
+            "name":    "Delhi",
+            "disease": "Black",
+            "neighbors": ["Tehran", "Kolkata", "Chennai", "Mumbai", "Karachi"]
+        },
+        {
+            "name":    "Karachi",
+            "disease": "Black",
+            "neighbors": ["Riydah", "Tehran", "Delhi", "Mumbai"]
+        },
+        {
+            "name":    "Mumbai",
+            "disease": "Black",
+            "neighbors": ["Karachi", "Delhi", "Chennai"]
+        },
+        {
+            "name":    "Kolkata",
+            "disease": "Black",
+            "neighbors": ["Chennai", "Delhi", "HongKong", "Bangkok"]
+        },
+        {
+            "name":    "Chennai",
+            "disease": "Black",
+            "neighbors": ["Mumbai", "Delhi", "Kolkata", "Jakarta"]
+        },
+        {
+            "name":    "Beijing",
+            "disease": "Red",
+            "neighbors": ["Shanghai", "Seoul"]
+        },
+        {
+            "name":    "Seoul",
+            "disease": "Red",
+            "neighbors": ["Beijing", "Tokyo", "Shanghai"]
+        },
+        {
+            "name":    "Tokyo",
+            "disease": "Red",
+            "neighbors": ["Shanghai", "Seoul", "SanFrancisco", "Osaka"]
+        },
+        {
+            "name":    "Shanghai",
+            "disease": "Red",
+            "neighbors": ["Beijing", "Seoul", "Tokyo", "Taipei", "HongKong"]
+        },
+        {
+            "name":    "Taipei",
+            "disease": "Red",
+            "neighbors": ["Shanghai", "Osaka", "Manila", "HongKong"]
+        },
+        {
+            "name":    "Osaka",
+            "disease": "Red",
+            "neighbors": ["Taipei", "Tokyo"]
+        },
+        {
+            "name":    "Hong Kong",
+            "disease": "Red",
+            "neighbors": ["Bangkok", "Kolkata", "Shanghai", "Taipei", "Manila", "HoChiMinhCity"]
+        },
+        {
+            "name":    "Bangkok",
+            "disease": "Red",
+            "neighbors": ["Kolkata", "HongKong", "HoChiMinhCity", "Jakarta"]
+        },
+        {
+            "name":    "HoChiMinhCity",
+            "disease": "Red",
+            "neighbors": ["Jakarta", "Bangkok", "HongKong", "Manila"]
+        },
+        {
+            "name":    "Jakarta",
+            "disease": "Red",
+            "neighbors": ["Chennai", "Bangkok", "HoChiMinhCity", "Sydney"]
+        },
+        {
+            "name":    "Manila",
+            "disease": "Red",
+            "neighbors": ["HoChiMinhCity", "HongKong", "Taipei", "SanFrancisco", "Sydney"]
+        },
+        {
+            "name":    "Sydney",
+            "disease": "Red",
+            "neighbors": ["Jakarta", "Manila", "LosAngeles"]
+        }
+    ]
+}

--- a/pandemic/cities.go
+++ b/pandemic/cities.go
@@ -1,5 +1,11 @@
 package pandemic
 
+import (
+	"encoding/json"
+	"fmt"
+)
+
+/* Panic Level */
 type PanicLevel int
 
 func (p PanicLevel) CanBuildResearchStations() bool {
@@ -15,12 +21,54 @@ const (
 	Fallen
 )
 
+func (pl *PanicLevel) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return fmt.Errorf("panic level should be a string, got %s", data)
+	}
+
+	got, ok := map[string]PanicLevel{
+		"Nothing":    Nothing,
+		"Unstable":   Unstable,
+		"Rioting2":   Rioting2,
+		"Rioting3":   Rioting3,
+		"Collapsing": Collapsing,
+		"Fallen":     Fallen,
+	}[s]
+	if !ok {
+		return fmt.Errorf("invalid PanicLevel %q", s)
+	}
+	*pl = got
+	return nil
+}
+
+/* Disease Type */
 type DiseaseType struct {
 	Color         string `json:"color"`
 	Incurable     bool   `json:"incurable,omitempty"`
 	Untreatable   bool   `json:"untreatable,omitempty"`
 	BecomingFaded bool   `json:"becoming_faded,omitempty"`
 	HasZombies    bool
+}
+
+func (dt *DiseaseType) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return fmt.Errorf("Disease Type should be a string, got %s", data)
+	}
+
+	got, ok := map[string]DiseaseType{
+		"Yellow": Yellow,
+		"Blue":   Blue,
+		"Red":    Red,
+		"Black":  Black,
+		"Faded":  Faded,
+	}[s]
+	if !ok {
+		return fmt.Errorf("invalid DiseaseType %q", s)
+	}
+	*dt = got
+	return nil
 }
 
 var Yellow = DiseaseType{
@@ -45,265 +93,23 @@ var Faded = DiseaseType{
 	Untreatable: true,
 }
 
+/* City + Cities */
 type City struct {
 	Name        string
 	Epidemic    bool
 	FundedEvent bool
 	Disease     DiseaseType
 	PanicLevel  PanicLevel
+	Neighbors   []string
 }
 
-var SanFrancisco = City{
-	Name:    "San Francisco",
-	Disease: Blue,
-}
-var Washington = City{
-	Name:    "Washington",
-	Disease: Blue,
-}
-var Atlanta = City{
-	Name:    "Atlanta",
-	Disease: Blue,
-}
-var Montreal = City{
-	Name:    "Montreal",
-	Disease: Blue,
-}
-var Chicago = City{
-	Name:    "Chicago",
-	Disease: Blue,
-}
-var NewYork = City{
-	Name:    "New York",
-	Disease: Blue,
-}
-var London = City{
-	Name:    "London",
-	Disease: Blue,
-}
-var Essen = City{
-	Name:    "Essen",
-	Disease: Blue,
-}
-var StPetersburg = City{
-	Name:    "St. Petersburg",
-	Disease: Blue,
-}
-var Milan = City{
-	Name:    "Milan",
-	Disease: Blue,
-}
-var Paris = City{
-	Name:    "Paris",
-	Disease: Blue,
-}
-var Madrid = City{
-	Name:    "Madrid",
-	Disease: Blue,
+type Cities struct {
+	Cities []City
 }
 
-var LosAngeles = City{
-	Name:    "Los Angeles",
-	Disease: Yellow,
-}
-
-var Miami = City{
-	Name:    "Miami",
-	Disease: Yellow,
-}
-var MexicoCity = City{
-	Name:    "Mexico City",
-	Disease: Yellow,
-}
-var Bogota = City{
-	Name:    "Bogota",
-	Disease: Yellow,
-}
-var Lima = City{
-	Name:    "Lima",
-	Disease: Yellow,
-}
-var Santiago = City{
-	Name:    "Santiago",
-	Disease: Yellow,
-}
-var SaoPaulo = City{
-	Name:    "Sao Paulo",
-	Disease: Yellow,
-}
-var BuenosAires = City{
-	Name:    "Buenos Aires",
-	Disease: Yellow,
-}
-var Lagos = City{
-	Name:    "Lagos",
-	Disease: Yellow,
-}
-var Khartoum = City{
-	Name:    "Khartoum",
-	Disease: Yellow,
-}
-var Kinshasa = City{
-	Name:    "Kinshasa",
-	Disease: Yellow,
-}
-var Johannesburg = City{
-	Name:    "Johannesburg",
-	Disease: Yellow,
-}
-
-var Algiers = City{
-	Name:    "Algiers",
-	Disease: Black,
-}
-var Istanbul = City{
-	Name:    "Istanbul",
-	Disease: Black,
-}
-var Cairo = City{
-	Name:    "Cairo",
-	Disease: Black,
-}
-var Riydah = City{
-	Name:    "Riydah",
-	Disease: Black,
-}
-var Baghdad = City{
-	Name:    "Baghdad",
-	Disease: Black,
-}
-var Moscow = City{
-	Name:    "Moscow",
-	Disease: Black,
-}
-var Tehran = City{
-	Name:    "Tehran",
-	Disease: Black,
-}
-var Delhi = City{
-	Name:    "Delhi",
-	Disease: Black,
-}
-var Karachi = City{
-	Name:    "Karachi",
-	Disease: Black,
-}
-var Mumbai = City{
-	Name:    "Mumbai",
-	Disease: Black,
-}
-var Kolkata = City{
-	Name:    "Kolkata",
-	Disease: Black,
-}
-var Chennai = City{
-	Name:    "Chennai",
-	Disease: Black,
-}
-
-var Beijing = City{
-	Name:    "Beijing",
-	Disease: Red,
-}
-var Seoul = City{
-	Name:    "Seoul",
-	Disease: Red,
-}
-var Tokyo = City{
-	Name:    "Tokyo",
-	Disease: Red,
-}
-var Shanghai = City{
-	Name:    "Shanghai",
-	Disease: Red,
-}
-var Taipei = City{
-	Name:    "Taipei",
-	Disease: Red,
-}
-var Osaka = City{
-	Name:    "Osaka",
-	Disease: Red,
-}
-var HongKong = City{
-	Name:    "HongKong",
-	Disease: Red,
-}
-var Bangkok = City{
-	Name:    "Bangkok",
-	Disease: Red,
-}
-var HoChiMinhCity = City{
-	Name:    "HoChiMinhCity",
-	Disease: Red,
-}
-var Jakarta = City{
-	Name:    "Jakarta",
-	Disease: Red,
-}
-var Manila = City{
-	Name:    "Manila",
-	Disease: Red,
-}
-var Sydney = City{
-	Name:    "Sydney",
-	Disease: Red,
-}
-
-var AllCities = []City{
-	SanFrancisco,
-	Washington,
-	Atlanta,
-	Montreal,
-	Chicago,
-	NewYork,
-	London,
-	Essen,
-	StPetersburg,
-	Milan,
-	Paris,
-	Madrid,
-	LosAngeles,
-	Miami,
-	MexicoCity,
-	Bogota,
-	Lima,
-	Santiago,
-	SaoPaulo,
-	BuenosAires,
-	Lagos,
-	Khartoum,
-	Kinshasa,
-	Johannesburg,
-	Algiers,
-	Istanbul,
-	Cairo,
-	Riydah,
-	Baghdad,
-	Moscow,
-	Tehran,
-	Delhi,
-	Karachi,
-	Mumbai,
-	Kolkata,
-	Chennai,
-	Beijing,
-	Seoul,
-	Tokyo,
-	Shanghai,
-	Taipei,
-	Osaka,
-	HongKong,
-	Bangkok,
-	HoChiMinhCity,
-	Jakarta,
-	Manila,
-	Sydney,
-}
-
-func AllCitiesWithDisease(disease DiseaseType) []City {
+func AllCitiesWithDisease(Cities []City, disease DiseaseType) []City {
 	cities := []City{}
-	for _, city := range AllCities {
+	for _, city := range Cities {
 		if city.Disease == disease {
 			cities = append(cities, city)
 		}

--- a/pandemic/cities_test.go
+++ b/pandemic/cities_test.go
@@ -1,0 +1,27 @@
+package pandemic
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+)
+
+func TestNeighbors(t *testing.T) {
+
+	// Do IO
+	filename, _ := filepath.Abs("../data/cities.json")
+	data, _ := ioutil.ReadFile(filename)
+	c := Cities{}
+
+	// Decode JSON
+	dec := json.NewDecoder(bytes.NewReader(data))
+	if err := dec.Decode(&c); err != nil {
+		fmt.Errorf("Decode city: %v", err)
+	}
+
+	fmt.Println(AllCitiesWithDisease(c.Cities, Blue))
+
+}

--- a/pandemic/record_test.go
+++ b/pandemic/record_test.go
@@ -14,11 +14,11 @@ func TestCardProbabilities(t *testing.T) {
 	}
 	deck.Drawn = []CityCard{
 		{
-			"San Francisco",
+			City{Name: "SanFrancisco"},
 			false,
 		},
 		{
-			"Sydney",
+			City{Name: "Sydney"},
 			false,
 		},
 	}
@@ -27,11 +27,13 @@ func TestCardProbabilities(t *testing.T) {
 	}
 	deck.Drawn = append(deck.Drawn,
 		CityCard{
-			"Epidemic!",
+			City{
+				Name: "Epidemic!",
+			},
 			true,
 		},
 		CityCard{
-			"Buenos Aires",
+			City{Name: "BuenosAires"},
 			false,
 		},
 	)


### PR DESCRIPTION
While we've moved from loading city structs directly from a JSON file,
we've kept in the DiseaseType structs and directly reference them when
deserializing. I'm not a huge fan of this bifrucated method of storing
information in JSON, but it's working for now.

I've also added the notion of a 'Neighbor' to a city, which will come in
handy when ultimately assigning some danger metric to a city, because we
will be able to calculate cascading outbreaks, etc.

Notes:
- Neighbors aren't City types because I can't figure out how to write a
  weak reference :(. One solution would be to have a global
  map[string][]City mappign of City name to cities, or an adjacency
  matrix to keep track of neighbors.

cc @anthonybishopric @macrael @bkoltai
