### PR TITLE
Add a simple string set

### DIFF
--- a/pandemic/set.go
+++ b/pandemic/set.go
@@ -1,0 +1,32 @@
+package pandemic
+
+type Set map[string]bool
+
+func Init(ks []string) Set {
+	s := Set{}
+	for _, k := range ks {
+		s[k] = true
+	}
+	return s
+}
+
+func (s Set) Contains(k string) bool {
+	return s[k] == true
+}
+
+func (s Set) Add(k string) Set {
+	s[k] = true
+	return s
+}
+
+func Intersection(s1 Set, s2 Set) Set {
+	s3 := Set{}
+
+	for k, _ := range s1 {
+		if s2.Contains(k) {
+			s3.Add(k)
+		}
+	}
+
+	return s3
+}

--- a/pandemic/set_test.go
+++ b/pandemic/set_test.go
@@ -1,0 +1,34 @@
+package pandemic
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestSetContains(t *testing.T) {
+	s := Init([]string{"a", "b"})
+
+	if c := s.Contains("a"); c != true {
+		t.Fatalf("Should have contained %v got %v", "a", c)
+	}
+
+	if c := s.Contains("c"); c != false {
+		t.Fatalf("Should not have contained %v got %v", "c", c)
+	}
+
+	s.Add("c")
+
+	if c := s.Contains("c"); c != true {
+		t.Fatalf("Should have contained %v got %v", "c", c)
+	}
+
+	s2 := Init([]string{"a"})
+
+	s3 := Intersection(s, s2)
+
+	if c := s3.Contains("a"); c != true {
+		t.Fatalf("Should have contained %v got %v", "a", c)
+	}
+
+	fmt.Println(s3)
+}


### PR DESCRIPTION
As titled. Adds a string set that is type'd to a `map[string]bool` and has basic `Init`, `Contains` and `Add` methods as well as a function `Intersection` that returns a new Set that is the intersection of two input `Set`s.
