### PR TITLE
Add a stack that we can use for storing striations

### DIFF
--- a/pandemic/set_test.go
+++ b/pandemic/set_test.go
@@ -1,7 +1,6 @@
 package pandemic
 
 import (
-	"fmt"
 	"testing"
 )
 
@@ -29,8 +28,6 @@ func TestSetContains(t *testing.T) {
 	if c := s3.Contains("a"); c != true {
 		t.Fatalf("Should have contained %v got %v", "a", c)
 	}
-
-	fmt.Println(s3)
 }
 
 func TestSet_Members(t *testing.T) {

--- a/pandemic/stack.go
+++ b/pandemic/stack.go
@@ -1,0 +1,36 @@
+package pandemic
+
+import (
+	"errors"
+)
+
+type Stack struct {
+	vs []interface{}
+}
+
+func NewStack() *Stack {
+	return &Stack{vs: make([]interface{}, 0)}
+}
+
+func (s *Stack) Push(v interface{}) *Stack {
+	s.vs = append([]interface{}{v}, s.vs...)
+	return s
+}
+
+func (s *Stack) Pop() (interface{}, error) {
+	l := len(s.vs)
+	if l == 0 {
+		return nil, errors.New("Empty stack")
+	}
+	head := s.vs[0]
+	s.vs = s.vs[1:]
+	return head, nil
+}
+
+func (s *Stack) Peek() interface{} {
+	l := len(s.vs)
+	if l == 0 {
+		return nil
+	}
+	return s.vs[0]
+}

--- a/pandemic/stack_test.go
+++ b/pandemic/stack_test.go
@@ -1,0 +1,35 @@
+package pandemic
+
+import (
+	"testing"
+)
+
+func TestStack(t *testing.T) {
+	s := NewStack()
+	s.Push(1).Push(2)
+
+	// Assert Peek LIFO
+	if head := s.Peek(); head != 2 {
+		t.Fatalf("A Peek should return the last element")
+	}
+
+	// Asset LIFO
+	if head, _ := s.Pop(); head != 2 {
+		t.Fatalf("Should have gotten last value pushed, got %v", head)
+	}
+
+	// Assert getting a single item
+	if head, _ := s.Pop(); head != 1 {
+		t.Fatalf("Should have gotten last value pushed, got %v", head)
+	}
+
+	// Assert we can handle empty stack
+	if _, err := s.Pop(); err == nil {
+		t.Fatalf("Should have gotten a 'stack empty' error, got %v", err)
+	}
+
+	// Assert we can handle empty stack again!
+	if _, err := s.Pop(); err == nil {
+		t.Fatalf("Should have gotten a 'stack empty' error, got %v", err)
+	}
+}


### PR DESCRIPTION
Our current code for InfectionDeck stores a list of Striations and does funky stuff to manually push/pop Sets from a Slice. This Stack is a simple LIFO Stack that can wrap some of that logic a little more cleanly.

This is the line of code that gave me pause…

``` lang=go
for d.Striations[0].Size() == 0 {
    d.Striations = d.Striations[1:]
}
```
