### PR TITLE
Updates for latest version of gocui.

### DIFF
--- a/view.go
+++ b/view.go
@@ -34,14 +34,14 @@ func NewView(logger *logrus.Logger) *PandemicView {
 }
 
 func (p *PandemicView) Start(game *pandemic.GameState) {
-	gui := gocui.NewGui()
+	gui, err := gocui.NewGui(gocui.OutputNormal)
 
-	if err := gui.Init(); err != nil {
+	if err != nil {
 		p.logger.Errorln("Could not init GUI: %v", err)
 	}
 	defer gui.Close()
 
-	gui.SetLayout(func(gui *gocui.Gui) error {
+	gui.SetManagerFunc(func(gui *gocui.Gui) error {
 		width, height := gui.Size()
 
 		p.renderCommandsView(game, gui, width)
@@ -52,7 +52,6 @@ func (p *PandemicView) Start(game *pandemic.GameState) {
 		p.setUpKeyBindings(game, gui, "Commands")
 		gui.Cursor = true
 		gui.SetCurrentView("Commands")
-		gui.Editor = gocui.DefaultEditor
 		return nil
 	})
 


### PR DESCRIPTION
This should be functionally the same, but caveat I did this pretty
mechanically and am not familiar with gocui library.

Compile errors on master that this change fixes:

```
./view.go:37: not enough arguments in call to gocui.NewGui
	have ()
	want (gocui.OutputMode)
./view.go:37: multiple-value gocui.NewGui() in single-value context
./view.go:55: gui.Editor undefined (type *gocui.Gui has no field or method Editor)
```

[Relevant Godocs](https://godoc.org/github.com/jroimartin/gocui)